### PR TITLE
Add myFAOS project to CV projects section

### DIFF
--- a/src/data/resume-data.tsx
+++ b/src/data/resume-data.tsx
@@ -162,5 +162,18 @@ export const RESUME_DATA = {
         href: "https://flexpoll.app",
       },
     },
+    {
+      title: "myFAOS",
+      techStack: ["Side Project", "React", "Vite", "Firebase"],
+      description: {
+        en: "A mobile-first family organizer with a shared calendar, tasks and child documentation",
+        de: "Ein mobile-first Familienorganizer mit geteiltem Kalender, Aufgaben und Kinddokumentation",
+      },
+      logo: ConsultlyLogo,
+      link: {
+        label: "myfaos.app",
+        href: "https://myfaos.app",
+      },
+    },
   ],
 } as const;


### PR DESCRIPTION
Adds `myfaos.app` as a new entry in the projects section of `src/data/resume-data.tsx`, placed after Flexpoll.

- **Tech stack:** Side Project, React, Vite, Firebase
- **Link:** [myfaos.app](https://myfaos.app)
- **Description (en):** A mobile-first family organizer with a shared calendar, tasks and child documentation
- **Description (de):** Ein mobile-first Familienorganizer mit geteiltem Kalender, Aufgaben und Kinddokumentation

Description and tech stack were derived from the README of `Gnadi/0815familyOS` (React 18 + Vite, Firebase Auth/Firestore, shared calendar plus task and documentation modules). The logo uses `ConsultlyLogo`, consistent with every other project entry — there is no dedicated myFAOS logo in the repo.

Data-only change following the exact shape of the existing project entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ88feaoWjm4N1APSju9LY)_