### PR TITLE
Fix: Disable autofocus on CommandInput for mobile devices

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -26,7 +26,11 @@ export const CommandMenu = () => {
   // Resolved after mount — the server has no way to know the platform.
   React.useEffect(() => {
     setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
-    setIsMobile(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
+    setIsMobile(
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent,
+      ),
+    );
   }, []);
 
   React.useEffect(() => {
@@ -60,7 +64,10 @@ export const CommandMenu = () => {
         <CommandIcon className="my-6 size-6" />
       </Button>
       <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput placeholder="Type a command or search..." autoFocus={!isMobile} />
+        <CommandInput
+          placeholder="Type a command or search..."
+          autoFocus={!isMobile}
+        />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Actions">

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -21,10 +21,12 @@ const links = RESUME_DATA.contact.social;
 export const CommandMenu = () => {
   const [open, setOpen] = React.useState(false);
   const [isMac, setIsMac] = React.useState(false);
+  const [isMobile, setIsMobile] = React.useState(false);
 
   // Resolved after mount — the server has no way to know the platform.
   React.useEffect(() => {
     setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
+    setIsMobile(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
   }, []);
 
   React.useEffect(() => {
@@ -58,7 +60,7 @@ export const CommandMenu = () => {
         <CommandIcon className="my-6 size-6" />
       </Button>
       <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput placeholder="Type a command or search..." />
+        <CommandInput placeholder="Type a command or search..." autoFocus={!isMobile} />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Actions">


### PR DESCRIPTION
On mobile, prevent the input field from automatically receiving focus when the command menu opens, allowing users to see the options clearly without the virtual keyboard blocking the view.