### PR TITLE
Keep the command menu's search input unfocused on touch devices

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,18 @@ export default defineConfig({
           : {},
       },
     },
+    {
+      // A real touchscreen, so the command menu's coarse-pointer handling is
+      // exercised the way a phone exercises it.
+      name: "mobile-chromium",
+      testMatch: /command-menu\.spec\.ts/,
+      use: {
+        ...devices["Pixel 5"],
+        launchOptions: process.env.PLAYWRIGHT_CHROMIUM_PATH
+          ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH }
+          : {},
+      },
+    },
   ],
   webServer: {
     command: `npm run build && npx next start -p ${PORT}`,

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -21,16 +21,14 @@ const links = RESUME_DATA.contact.social;
 export const CommandMenu = () => {
   const [open, setOpen] = React.useState(false);
   const [isMac, setIsMac] = React.useState(false);
-  const [isMobile, setIsMobile] = React.useState(false);
+  const [isTouch, setIsTouch] = React.useState(false);
 
   // Resolved after mount — the server has no way to know the platform.
   React.useEffect(() => {
     setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
-    setIsMobile(
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent,
-      ),
-    );
+    // A coarse primary pointer means a touchscreen without a mouse, i.e. a
+    // device that answers keyboard focus with an on-screen keyboard.
+    setIsTouch(window.matchMedia("(pointer: coarse)").matches);
   }, []);
 
   React.useEffect(() => {
@@ -44,6 +42,16 @@ export const CommandMenu = () => {
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
   }, []);
+
+  // On open the dialog focuses its first tabbable child, which is the search
+  // input. On touch devices that raises the virtual keyboard and buries the
+  // options, so focus the dialog itself instead — the input is one tap away
+  // for anyone who actually wants to search.
+  const handleOpenAutoFocus = (event: Event) => {
+    if (!isTouch) return;
+    event.preventDefault();
+    (event.currentTarget as HTMLElement | null)?.focus({ preventScroll: true });
+  };
 
   return (
     <>
@@ -63,11 +71,12 @@ export const CommandMenu = () => {
       >
         <CommandIcon className="my-6 size-6" />
       </Button>
-      <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput
-          placeholder="Type a command or search..."
-          autoFocus={!isMobile}
-        />
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        onOpenAutoFocus={handleOpenAutoFocus}
+      >
+        <CommandInput placeholder="Type a command or search..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Actions">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -24,12 +24,27 @@ const Command = React.forwardRef<
 
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+interface CommandDialogProps extends DialogProps {
+  /**
+   * Runs when the dialog grabs focus on open. Calling `preventDefault()` keeps
+   * focus off the search input — see the touch handling in `CommandMenu`.
+   */
+  onOpenAutoFocus?: React.ComponentPropsWithoutRef<
+    typeof DialogContent
+  >["onOpenAutoFocus"];
+}
 
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({
+  children,
+  onOpenAutoFocus,
+  ...props
+}: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden rounded-xl p-0 shadow-2xl sm:rounded-xl">
+      <DialogContent
+        onOpenAutoFocus={onOpenAutoFocus}
+        className="overflow-hidden rounded-xl p-0 shadow-2xl sm:rounded-xl"
+      >
         <div className="flex items-center gap-2 border-b px-4 py-3">
           <CommandIcon className="h-4 w-4 text-muted-foreground" />
           <DialogTitle className="text-sm font-semibold">

--- a/tests/command-menu.spec.ts
+++ b/tests/command-menu.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+const PLACEHOLDER = "Type a command or search...";
+
+const onTouch = () => test.info().project.name === "mobile-chromium";
+
+test.describe("command menu", () => {
+  test("a mouse-and-keyboard visitor lands in the search input", async ({
+    page,
+  }) => {
+    test.skip(onTouch(), "covered by the touch case below");
+    await page.goto("/en");
+    await page.keyboard.press("Control+j");
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByPlaceholder(PLACEHOLDER)).toBeFocused();
+  });
+
+  test("a touch visitor sees the options instead of the keyboard", async ({
+    page,
+  }) => {
+    test.skip(!onTouch(), "needs a coarse pointer");
+    await page.goto("/en");
+    await page.getByRole("button", { name: "open command menu" }).tap();
+
+    // Focus lands on the dialog, not the input: a focused input raises the
+    // virtual keyboard, which covers the very options the menu is opened for.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(page.getByPlaceholder(PLACEHOLDER)).not.toBeFocused();
+    await expect(dialog).toBeFocused();
+    await expect(page.getByText("Print / Save as PDF")).toBeVisible();
+
+    // Searching still works, it just waits to be asked for.
+    await page.getByPlaceholder(PLACEHOLDER).tap();
+    await expect(page.getByPlaceholder(PLACEHOLDER)).toBeFocused();
+  });
+});


### PR DESCRIPTION
The previous attempt set autoFocus={false} on the input, but that is not
what focuses it: Radix's DialogContent moves focus to the first tabbable
child when the dialog opens, and that child is the search input. The
virtual keyboard then covers the options the menu was opened for.

Prevent the dialog's open-autofocus on a coarse primary pointer and focus
the dialog container instead, so the options are visible and the input is
one tap away. Detection moves from user-agent sniffing to a pointer media
query, which also catches iPadOS reporting itself as a Mac.

Adds a Pixel 5 Playwright project and a spec covering both pointer types;
the touch case fails against the previous implementation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QanEGNE9MsgUpcSBU4Ekrv