### PR TITLE
Reposition the CV as a Payments & Backend Engineer profile

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -6,19 +6,25 @@ import { notFound } from "next/navigation";
 import "../globals.css";
 import React from "react";
 import { ThemeScript } from "@/components/theme-script";
+import { PersonJsonLd } from "@/components/person-json-ld";
+import { RESUME_DATA } from "@/data/resume-data";
 import { LANGUAGES, isLanguage, type Language } from "@/lib/i18n";
 import { siteUrl } from "@/lib/site";
 
+// Built from the canonical role in RESUME_DATA rather than restated, so the
+// title cannot drift away from the headline the page renders.
+const ROLE = RESUME_DATA.headline.role;
+
 const META: Record<Language, { title: string; description: string }> = {
   en: {
-    title: "Johannes Gnadlinger | Payments Engineer & former Product Owner",
+    title: `Johannes Gnadlinger — ${ROLE.en}`,
     description:
-      "CV of Johannes Gnadlinger — Payments Engineer and former Product Owner in banking payments (EBICS/SEPA) at Raiffeisen Software, Linz. Regulated financial infrastructure and AI-assisted product development.",
+      "Payments & Backend Engineer at Raiffeisen Software in Linz, Austria. 8+ years building payment systems for corporate banking — SEPA, EBICS and Java backend services. Former Product Owner.",
   },
   de: {
-    title: "Johannes Gnadlinger | Payments Engineer & ehem. Product Owner",
+    title: `Johannes Gnadlinger — ${ROLE.de}`,
     description:
-      "Lebenslauf von Johannes Gnadlinger — Payments Engineer und ehemaliger Product Owner im Zahlungsverkehr (EBICS/SEPA) bei Raiffeisen Software, Linz. Regulierte Finanzinfrastruktur und KI-gestützte Produktentwicklung.",
+      "Payments & Backend Engineer bei Raiffeisen Software in Linz. Über 8 Jahre Erfahrung mit Zahlungsverkehrssystemen im Firmenkundengeschäft — SEPA, EBICS und Java-Backend-Services. Zuvor Product Owner.",
   },
 };
 
@@ -58,6 +64,8 @@ export async function generateMetadata({
       title,
       description,
       type: "profile",
+      firstName: "Johannes",
+      lastName: "Gnadlinger",
       locale: lang === "de" ? "de_AT" : "en_US",
       url: `/${lang}`,
     },
@@ -83,6 +91,7 @@ export default async function RootLayout({
     <html lang={lang} className={inter.className} suppressHydrationWarning>
       <head>
         <ThemeScript />
+        <PersonJsonLd lang={lang} />
       </head>
       <body>{children}</body>
       <Analytics />

--- a/src/app/[lang]/opengraph-image.tsx
+++ b/src/app/[lang]/opengraph-image.tsx
@@ -41,16 +41,18 @@ export default async function OpengraphImage({
       <div style={{ fontSize: 68, fontWeight: 700, letterSpacing: "-0.02em" }}>
         {RESUME_DATA.name}
       </div>
+      <div style={{ marginTop: 24, fontSize: 40, fontWeight: 600 }}>
+        {t(RESUME_DATA.headline.role)}
+      </div>
       <div
         style={{
-          marginTop: 28,
-          fontSize: 32,
+          marginTop: 16,
+          fontSize: 28,
           lineHeight: 1.4,
           color: "#4b5563",
-          whiteSpace: "pre-line",
         }}
       >
-        {t(RESUME_DATA.about)}
+        {t(RESUME_DATA.headline.tagline)}
       </div>
       <div
         style={{

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -24,14 +24,22 @@ export default async function Page({
 
   return (
     <main className="container relative mx-auto scroll-my-12 overflow-auto p-4 md:p-16 print:p-0">
-      <section className="mx-auto w-full max-w-2xl space-y-8 print:space-y-2">
+      <section className="mx-auto w-full max-w-2xl space-y-8 print:space-y-1.5">
         <div className="flex items-center justify-between">
           <div className="flex-1 space-y-1.5">
             <h1 className="text-xl font-bold print:text-[15px]">
               {RESUME_DATA.name}
             </h1>
-            <p className="mr-5 max-w-md whitespace-pre-line font-mono text-sm text-muted-foreground print:text-[10px] print:leading-snug">
-              {t(RESUME_DATA.about)}
+            {/* The positioning, not the name, is what has to land first — so it
+                gets its own weight instead of sharing the muted intro block. */}
+            <p className="text-base font-semibold leading-tight text-foreground print:text-[12px]">
+              {t(RESUME_DATA.headline.role)}
+            </p>
+            <p className="mr-5 max-w-md text-pretty font-mono text-sm text-muted-foreground print:text-[10px] print:leading-snug">
+              {t(RESUME_DATA.headline.tagline)}
+            </p>
+            <p className="mr-5 max-w-md text-pretty font-mono text-xs text-muted-foreground print:text-[9px] print:leading-snug">
+              {t(RESUME_DATA.headline.credentials)}
             </p>
             <p className="max-w-md items-center text-pretty font-mono text-xs text-muted-foreground">
               <a
@@ -97,7 +105,7 @@ export default async function Page({
           <h2 className="text-xl font-bold print:text-[15px]">
             {t(RESUME_DATA.sections.about)}
           </h2>
-          <p className="text-pretty font-mono text-sm text-muted-foreground print:text-[10px] print:leading-snug">
+          <p className="whitespace-pre-line text-pretty font-mono text-sm text-muted-foreground print:text-[10px] print:leading-snug">
             {t(RESUME_DATA.summary)}
           </p>
         </Section>
@@ -107,7 +115,9 @@ export default async function Page({
           </h2>
           {RESUME_DATA.work.map((work) => {
             return (
-              <Card key={work.company}>
+              // Both phases are the same employer, so the start year is what
+              // makes the key unique.
+              <Card key={`${work.company}-${work.start}`}>
                 <CardHeader>
                   <div className="flex items-center justify-between gap-x-2 text-base">
                     <h3 className="inline-flex items-center justify-center gap-x-1 font-semibold leading-none">
@@ -140,17 +150,76 @@ export default async function Page({
                     </div>
                   </div>
 
-                  <h4 className="font-mono text-sm leading-none print:text-[10px]">
-                    {work.title}
+                  <h4 className="font-mono text-sm font-medium leading-none text-foreground print:text-[10px]">
+                    {t(work.title)}
                   </h4>
                 </CardHeader>
-                <CardContent className="mt-2 whitespace-pre-wrap text-sm print:mt-1 print:text-[10px] print:leading-snug">
-                  {t(work.description)}
+                <CardContent className="mt-2 text-sm print:mt-0.5 print:text-[10px] print:leading-snug">
+                  <p className="text-pretty">{t(work.intro)}</p>
+                  {/* Two work cards with bullets cost more paper than the old
+                      single block, so print gets its own tighter metrics. */}
+                  <ul className="mt-1.5 list-outside list-disc space-y-1 pl-4 text-muted-foreground print:mt-0.5 print:space-y-0 print:pl-3 print:text-[9px] print:leading-tight">
+                    {work.highlights.map((highlight) => (
+                      <li className="text-pretty" key={highlight.en}>
+                        {t(highlight)}
+                      </li>
+                    ))}
+                  </ul>
                 </CardContent>
               </Card>
             );
           })}
         </Section>
+        <Section>
+          <h2 className="text-xl font-bold print:text-[15px]">
+            {t(RESUME_DATA.sections.skills)}
+          </h2>
+          <div className="flex flex-col gap-y-2 print:gap-y-0.5">
+            {RESUME_DATA.skillGroups.map((group) => (
+              <div
+                key={group.label.en}
+                className="flex flex-col gap-y-1 sm:flex-row sm:items-baseline sm:gap-x-3 print:flex-row print:items-baseline print:gap-x-2 print:gap-y-0"
+              >
+                <h3 className="shrink-0 font-mono text-xs font-semibold text-muted-foreground sm:w-48 print:w-36 print:text-[9px]">
+                  {t(group.label)}
+                </h3>
+                <div className="flex flex-wrap gap-1">
+                  {group.skills.map((skill) => {
+                    const label = typeof skill === "string" ? skill : t(skill);
+                    return (
+                      <Badge
+                        key={typeof skill === "string" ? skill : skill.en}
+                        className="print:px-1 print:py-0 print:text-[9px]"
+                      >
+                        {label}
+                      </Badge>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section className="scroll-mb-16">
+          <h2 className="text-xl font-bold print:text-[15px]">
+            {t(RESUME_DATA.sections.projects)}
+          </h2>
+          <div className="print-projects-grid -mx-3 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 print:grid-cols-3 print:gap-2">
+            {RESUME_DATA.projects.map((project) => {
+              return (
+                <ProjectCard
+                  key={project.title}
+                  title={project.title}
+                  description={t(project.description)}
+                  tags={project.techStack}
+                  link={"link" in project ? project.link.href : undefined}
+                />
+              );
+            })}
+          </div>
+        </Section>
+
         <Section>
           <h2 className="text-xl font-bold print:text-[15px]">
             {t(RESUME_DATA.sections.education)}
@@ -182,59 +251,6 @@ export default async function Page({
               </Card>
             );
           })}
-        </Section>
-        <Section>
-          <h2 className="text-xl font-bold print:text-[15px]">
-            {t(RESUME_DATA.sections.skills)}
-          </h2>
-          <div className="flex flex-wrap gap-1">
-            {RESUME_DATA.skills.map((skill) => {
-              return (
-                <Badge
-                  key={skill}
-                  className="print:px-1 print:py-0 print:text-[9px]"
-                >
-                  {skill}
-                </Badge>
-              );
-            })}
-          </div>
-        </Section>
-        <Section>
-          <h2 className="text-xl font-bold print:text-[15px]">
-            {t(RESUME_DATA.sections.aiSkills)}
-          </h2>
-          <div className="flex flex-wrap gap-1">
-            {RESUME_DATA.aiSkills.map((skill) => {
-              return (
-                <Badge
-                  key={skill}
-                  className="print:px-1 print:py-0 print:text-[9px]"
-                >
-                  {skill}
-                </Badge>
-              );
-            })}
-          </div>
-        </Section>
-
-        <Section className="scroll-mb-16">
-          <h2 className="text-xl font-bold print:text-[15px]">
-            {t(RESUME_DATA.sections.projects)}
-          </h2>
-          <div className="print-projects-grid -mx-3 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 print:grid-cols-3 print:gap-2">
-            {RESUME_DATA.projects.map((project) => {
-              return (
-                <ProjectCard
-                  key={project.title}
-                  title={project.title}
-                  description={t(project.description)}
-                  tags={project.techStack}
-                  link={"link" in project ? project.link.href : undefined}
-                />
-              );
-            })}
-          </div>
         </Section>
       </section>
 

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -23,7 +23,9 @@ export default async function Page({
   const t = createTranslator(lang);
 
   return (
-    <main className="container relative mx-auto scroll-my-12 overflow-auto p-4 md:p-16 print:p-0">
+    // Extra bottom padding below xl: that is where the floating command-menu
+    // button sits, and on a phone it lands on top of the last project card.
+    <main className="container relative mx-auto scroll-my-12 overflow-auto p-4 pb-28 md:p-16 md:pb-28 xl:pb-16 print:p-0">
       <section className="mx-auto w-full max-w-2xl space-y-8 print:space-y-1.5">
         <div className="flex items-center justify-between">
           <div className="flex-1 space-y-1.5">

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -105,9 +105,16 @@ export default async function Page({
           <h2 className="text-xl font-bold print:text-[15px]">
             {t(RESUME_DATA.sections.about)}
           </h2>
-          <p className="whitespace-pre-line text-pretty font-mono text-sm text-muted-foreground print:text-[10px] print:leading-snug">
-            {t(RESUME_DATA.summary)}
-          </p>
+          {/* Split into real paragraphs rather than a pre-line block: the blank
+              line a "\n\n" renders costs a full line of paper, and German runs
+              longer than English to begin with. */}
+          <div className="space-y-2 text-pretty font-mono text-sm text-muted-foreground print:space-y-1 print:text-[9px] print:leading-tight">
+            {t(RESUME_DATA.summary)
+              .split("\n\n")
+              .map((paragraph) => (
+                <p key={paragraph.slice(0, 24)}>{paragraph}</p>
+              ))}
+          </div>
         </Section>
         <Section>
           <h2 className="text-xl font-bold print:text-[15px]">
@@ -154,7 +161,7 @@ export default async function Page({
                     {t(work.title)}
                   </h4>
                 </CardHeader>
-                <CardContent className="mt-2 text-sm print:mt-0.5 print:text-[10px] print:leading-snug">
+                <CardContent className="mt-2 text-sm print:mt-0.5 print:text-[10px] print:leading-tight">
                   <p className="text-pretty">{t(work.intro)}</p>
                   {/* Two work cards with bullets cost more paper than the old
                       single block, so print gets its own tighter metrics. */}
@@ -201,25 +208,6 @@ export default async function Page({
           </div>
         </Section>
 
-        <Section className="scroll-mb-16">
-          <h2 className="text-xl font-bold print:text-[15px]">
-            {t(RESUME_DATA.sections.projects)}
-          </h2>
-          <div className="print-projects-grid -mx-3 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 print:grid-cols-3 print:gap-2">
-            {RESUME_DATA.projects.map((project) => {
-              return (
-                <ProjectCard
-                  key={project.title}
-                  title={project.title}
-                  description={t(project.description)}
-                  tags={project.techStack}
-                  link={"link" in project ? project.link.href : undefined}
-                />
-              );
-            })}
-          </div>
-        </Section>
-
         <Section>
           <h2 className="text-xl font-bold print:text-[15px]">
             {t(RESUME_DATA.sections.education)}
@@ -245,12 +233,31 @@ export default async function Page({
                     </div>
                   </div>
                 </CardHeader>
-                <CardContent className="mt-2 print:mt-1 print:text-[10px]">
+                <CardContent className="mt-2 print:mt-0.5 print:text-[9px]">
                   {t(education.degree)}
                 </CardContent>
               </Card>
             );
           })}
+        </Section>
+
+        <Section className="scroll-mb-16">
+          <h2 className="text-xl font-bold print:text-[15px]">
+            {t(RESUME_DATA.sections.projects)}
+          </h2>
+          <div className="print-projects-grid -mx-3 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 print:grid-cols-3 print:gap-2">
+            {RESUME_DATA.projects.map((project) => {
+              return (
+                <ProjectCard
+                  key={project.title}
+                  title={project.title}
+                  description={t(project.description)}
+                  tags={project.techStack}
+                  link={"link" in project ? project.link.href : undefined}
+                />
+              );
+            })}
+          </div>
         </Section>
       </section>
 

--- a/src/components/person-json-ld.tsx
+++ b/src/components/person-json-ld.tsx
@@ -1,0 +1,61 @@
+import { RESUME_DATA } from "@/data/resume-data";
+import { createTranslator, type Language, type Translated } from "@/lib/i18n";
+import { siteUrl } from "@/lib/site";
+
+const resolve = (t: (value: Translated) => string) => {
+  return (value: string | Translated) =>
+    typeof value === "string" ? value : t(value);
+};
+
+/**
+ * schema.org/Person for the CV.
+ *
+ * Rendered by a server component inside prerendered routes, so the markup is
+ * baked into the static HTML at build time and costs no client-side JS. Every
+ * value is read from RESUME_DATA rather than restated here, so the structured
+ * data and the visible page cannot disagree.
+ */
+export function PersonJsonLd({ lang }: { lang: Language }) {
+  const t = createTranslator(lang);
+  const text = resolve(t);
+
+  const person = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Johannes Gnadlinger",
+    honorificPrefix: "Ing.",
+    jobTitle: t(RESUME_DATA.headline.role),
+    description: t(RESUME_DATA.headline.tagline),
+    url: siteUrl,
+    image: `${siteUrl}${RESUME_DATA.avatarUrl}`,
+    email: `mailto:${RESUME_DATA.contact.email}`,
+    worksFor: {
+      "@type": "Organization",
+      name: RESUME_DATA.work[0].company,
+      url: RESUME_DATA.work[0].link,
+    },
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Linz",
+      addressCountry: "AT",
+    },
+    knowsAbout: RESUME_DATA.knowsAbout.map(text),
+    // Derived from the contact links so the identity graph published here stays
+    // in step with the links the page actually renders.
+    sameAs: [
+      ...RESUME_DATA.contact.social.map((social) => social.url),
+      RESUME_DATA.contact.stackOverflow,
+    ],
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      // The payload is static, authored content — but escaping `<` keeps a
+      // stray "</script>" in future copy from breaking out of the tag.
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(person).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}

--- a/src/components/ui/section.tsx
+++ b/src/components/ui/section.tsx
@@ -6,7 +6,7 @@ export interface SectionProps extends React.HTMLAttributes<HTMLElement> {}
 export function Section({ className, ...props }: SectionProps) {
   return (
     <section
-      className={cn("flex min-h-0 flex-col gap-y-3 print:gap-y-1.5", className)}
+      className={cn("flex min-h-0 flex-col gap-y-3 print:gap-y-1", className)}
       {...props}
     />
   );

--- a/src/data/resume-data.tsx
+++ b/src/data/resume-data.tsx
@@ -1,27 +1,46 @@
 import { ConsultlyLogo, ParabolLogo } from "@/images/logos";
 import { GitHubIcon, LinkedInIcon } from "@/components/icons";
 import { WebsiteIcon } from "@/components/icons/WebsiteIcon";
+import { Rss } from "lucide-react";
 
 export const RESUME_DATA = {
   name: "Ing. Johannes Gnadlinger",
   initials: "JG",
   location: "Linz, Österreich",
   locationLink: "https://www.google.com/maps/place/Linz",
-  about: {
-    en: "Payments Engineer, previously Product Owner\nbuilding regulated financial infrastructure — EBICS, SEPA, AI-assisted products",
-    de: "Payments Engineer, zuvor Product Owner\nAufbau regulierter Finanzinfrastruktur — EBICS, SEPA, KI-gestützte Produkte",
+  // The canonical positioning. Every other surface — metadata, OpenGraph,
+  // JSON-LD — derives its wording from here so the claim stays identical.
+  headline: {
+    role: {
+      en: "Payments & Backend Engineer",
+      de: "Payments & Backend Engineer",
+    },
+    tagline: {
+      en: "Building reliable financial infrastructure for corporate banking — SEPA, EBICS, Java",
+      de: "Verlässliche Finanzinfrastruktur für das Firmenkundengeschäft — SEPA, EBICS, Java",
+    },
+    credentials: {
+      en: "Former Product Owner · 8+ years in banking software · Independent product builder",
+      de: "Ehem. Product Owner · 8+ Jahre Banking-Software · Eigenständiger Produktentwickler",
+    },
   },
   summary: {
-    en: "As a Payments Engineer and former Product Owner at Raiffeisen Software GmbH, I've taken multiple banking products from 0 to 1. I led a team in corporate banking building communication tools between advisors and corporate customers, worked on payment and financial services (EBICS/SEPA), and earlier built advisor-customer communication features in private banking — all backed by deep expertise in Angular and Java.",
-    de: "Als Payments Engineer und ehemaliger Product Owner bei der Raiffeisen Software GmbH habe ich mehrere Banking-Produkte von 0 auf 1 gebracht. Ich habe ein Team im Firmenkundenbanking geleitet, das Kommunikationstools zwischen Beratern und Firmenkunden entwickelt hat, im Zahlungsverkehr und Finanzdienstleistungsbereich (EBICS/SEPA) gearbeitet und zuvor im Privatkundenbanking Kommunikationsfunktionen zwischen Kunden und Beratern entwickelt — mit fundierter Expertise in Angular und Java.",
+    en:
+      "Payments-focused Backend Engineer with 8+ years of experience building production software for regulated banking environments. Specialized in corporate payment systems, SEPA, EBICS and Java-based backend development, with experience taking financial products from 0 to 1.\n\n" +
+      "Previously served as Product Owner in corporate banking, combining hands-on engineering with product ownership, stakeholder alignment and domain expertise. Outside my professional work, I independently design and ship software products using modern AI-assisted engineering workflows.",
+    de:
+      "Payments-fokussierter Backend Engineer mit über 8 Jahren Erfahrung in der Entwicklung produktiver Software für regulierte Bankenumgebungen. Spezialisiert auf Zahlungsverkehr im Firmenkundengeschäft, SEPA, EBICS und Java-Backend-Entwicklung — inklusive Erfahrung darin, Finanzprodukte von 0 auf 1 zu bringen.\n\n" +
+      "Zuvor als Product Owner im Firmenkundengeschäft tätig und damit Engineering, Product Ownership, Stakeholder-Abstimmung und Fachdomänenwissen in einer Rolle vereint. Außerhalb meiner beruflichen Tätigkeit entwerfe und veröffentliche ich eigenständig Softwareprodukte mit modernen KI-gestützten Engineering-Workflows.",
   },
   sections: {
-    about: { en: "About", de: "Über mich" },
-    work: { en: "Work Experience", de: "Berufserfahrung" },
-    education: { en: "Education", de: "Ausbildung" },
-    skills: { en: "Skills", de: "Kenntnisse" },
-    aiSkills: { en: "AI Skills", de: "KI-Kenntnisse" },
-    projects: { en: "Projects", de: "Projekte" },
+    about: { en: "Summary", de: "Profil" },
+    work: { en: "Professional Experience", de: "Berufserfahrung" },
+    education: {
+      en: "Education & Qualifications",
+      de: "Ausbildung & Qualifikationen",
+    },
+    skills: { en: "Core Expertise", de: "Kernkompetenzen" },
+    projects: { en: "Selected Projects", de: "Ausgewählte Projekte" },
   },
   ui: {
     emailMe: { en: "Email me", de: "E-Mail schreiben" },
@@ -43,26 +62,36 @@ export const RESUME_DATA = {
       },
       {
         name: "LinkedIn",
-        url: "https://at.linkedin.com/in/johannes-gnadlinger-842293271",
+        // Kept on the www host so the profile URL is byte-identical to the
+        // sameAs entry published on every other property.
+        url: "https://www.linkedin.com/in/johannes-gnadlinger-842293271",
         icon: LinkedInIcon,
       },
       {
         name: "Website",
-        url: "https://gnadlinger.me",
+        url: "https://www.gnadlinger.me",
         icon: WebsiteIcon,
       },
+      {
+        name: "Blog",
+        url: "https://blog.gnadlinger.me",
+        icon: Rss,
+      },
     ],
+    // Not shown as a header icon, but part of the published identity graph.
+    stackOverflow:
+      "https://stackoverflow.com/users/6504152/johannes-gnadlinger",
   },
   education: [
     {
-      school: "Gymnasium Dr.- Schauerstraße",
-      link: "https://schauergym.at/",
+      school: "WKO Oberösterreich",
+      link: "https://www.wko.at/ooe",
       degree: {
-        en: "Technical Education",
-        de: "Technische Ausbildung",
+        en: "Engineering Qualification (Ing.) — NQF/EQF Level 6",
+        de: "Ingenieurqualifikation (Ing.) — NQR/EQR Niveau 6",
       },
-      start: "2009",
-      end: "2013",
+      start: "2026",
+      end: "",
     },
     {
       school: "HTL Leonding",
@@ -74,93 +103,153 @@ export const RESUME_DATA = {
       start: "2013",
       end: "2017",
     },
-    {
-      school: "WKO Oberösterreich",
-      link: "https://www.wko.at/ooe",
-      degree: {
-        en: "Engineering Degree",
-        de: "Ingenieur Zertifizierung",
-      },
-      start: "2026",
-      end: "",
-    },
   ],
+  // Split into the two career phases the tenure actually consists of, so the
+  // progression Full Stack → Product Owner → Payments/Backend is readable at a
+  // glance instead of hidden inside one combined description.
   work: [
     {
       company: "Raiffeisen Software GmbH",
       link: "https://r-software.at",
       badges: ["Linz"],
-      title: "Full Stack Developer & Product Owner",
+      title: {
+        en: "Payments & Backend Engineer",
+        de: "Payments & Backend Engineer",
+      },
       logo: ParabolLogo,
-      start: "2018",
+      start: "2023",
       end: {
-        en: "now",
+        en: "Present",
         de: "heute",
       },
-      description: {
-        en:
-          "2018 - 2022: Developer in Team VT, building private banking communication features between customers and their advisors, and corporate banking features for advisor and insurance interaction. Also served as Product Owner, leading a team in corporate banking that built communication tools between advisors and corporate customers. \n \n" +
-          "2023 - now: Developer in Team ZV, working on payment and financial services in corporate banking — developing new payment transaction features and migrating from MBS to the EBICS banking standard.",
-        de:
-          "2018 - 2022: Entwickler im Team VT, Entwicklung von Kommunikationsfunktionen im Privatkundenbanking zwischen Kunden und ihren Beratern sowie Firmenkundenbanking-Features zur Interaktion mit Beratern und Versicherungen. Zusätzlich als Product Owner tätig mit Leitung eines Teams im Firmenkundenbanking, das Kommunikationstools zwischen Beratern und Firmenkunden entwickelt hat. \n \n" +
-          "2023 - heute: Entwickler im Team ZV, Tätigkeit im Zahlungsverkehr und Finanzdienstleistungsbereich im Firmenkundenbanking — Entwicklung neuer Zahlungsverkehrs-Features und Migration vom MBS- zum EBICS-Banking-Standard.",
+      intro: {
+        en: "Developing backend systems for corporate payment and financial services in a regulated banking environment.",
+        de: "Entwicklung von Backend-Systemen für Zahlungsverkehr und Finanzdienstleistungen im Firmenkundengeschäft — in einem regulierten Bankenumfeld.",
       },
+      highlights: [
+        {
+          en: "Build and evolve payment transaction functionality for corporate banking.",
+          de: "Entwicklung und Weiterentwicklung von Zahlungsverkehrsfunktionen für das Firmenkundengeschäft.",
+        },
+        {
+          en: "Work on the migration from the Austrian MBS communication standard to EBICS.",
+          de: "Mitarbeit an der Migration vom österreichischen MBS-Kommunikationsstandard auf EBICS.",
+        },
+        {
+          en: "Develop Java-based backend services with a focus on correctness, reliability and maintainability.",
+          de: "Entwicklung Java-basierter Backend-Services mit Fokus auf Korrektheit, Verlässlichkeit und Wartbarkeit.",
+        },
+        {
+          en: "Work across payment-domain requirements, implementation, testing and production operations.",
+          de: "Begleitung des gesamten Wegs von fachlichen Anforderungen im Zahlungsverkehr über Umsetzung und Test bis in den Produktionsbetrieb.",
+        },
+        {
+          en: "Contribute domain expertise in payment processing, SEPA and bank-customer communication.",
+          de: "Einbringen von Fachwissen in Zahlungsverarbeitung, SEPA und Bank-Kunde-Kommunikation.",
+        },
+      ],
+    },
+    {
+      company: "Raiffeisen Software GmbH",
+      link: "https://r-software.at",
+      badges: ["Linz"],
+      title: {
+        en: "Full Stack Developer & Product Owner",
+        de: "Full Stack Developer & Product Owner",
+      },
+      logo: ParabolLogo,
+      start: "2018",
+      end: "2022",
+      intro: {
+        en: "Built digital banking products across private and corporate banking, progressing from hands-on full-stack development into product ownership.",
+        de: "Entwicklung digitaler Banking-Produkte im Privat- und Firmenkundengeschäft — vom Full-Stack-Development bis in die Product Ownership.",
+      },
+      highlights: [
+        {
+          en: "Developed customer–advisor communication features in private banking.",
+          de: "Entwicklung von Kommunikationsfunktionen zwischen Kunden und ihren Beratern im Privatkundenbanking.",
+        },
+        {
+          en: "Built corporate banking functionality for advisor and insurance interaction.",
+          de: "Umsetzung von Firmenkundenbanking-Funktionen für die Interaktion mit Beratern und Versicherungen.",
+        },
+        {
+          en: "Served as Product Owner for corporate banking products, leading the team behind advisor–customer communication tools and owning requirements and stakeholder alignment.",
+          de: "Product Owner für Firmenkundenprodukte: Leitung des Teams hinter den Kommunikationstools zwischen Beratern und Firmenkunden, verantwortlich für Anforderungen und Stakeholder-Abstimmung.",
+        },
+        {
+          en: "Took functionality from concept through implementation to production.",
+          de: "Begleitung von Funktionen von der Konzeption über die Umsetzung bis in die Produktion.",
+        },
+        {
+          en: "Worked across Java backend and Angular frontend.",
+          de: "Java-Backend- und Angular-Frontend-Entwicklung.",
+        },
+      ],
     },
   ],
-  skills: [
-    "Angular",
-    "TypeScript",
-    "Java",
-    "Quarkus",
-    "Open Liberty",
-    "Splunk",
-    "Dynatrace",
-    "Openshift",
-    "XL Release",
-    "Microsoft SQL Server",
-    "Mongo DB",
-    "React/Next.js",
+  // Grouped rather than one flat badge cloud, so the payments and backend
+  // depth reads first and the frontend/AI tooling stays supporting context.
+  skillGroups: [
+    {
+      label: {
+        en: "Payments & Financial Systems",
+        de: "Zahlungsverkehr & Finanzsysteme",
+      },
+      skills: [
+        "SEPA",
+        "EBICS",
+        { en: "Corporate Banking", de: "Firmenkundengeschäft" },
+        { en: "Payment Transactions", de: "Zahlungsverkehr" },
+      ],
+    },
+    {
+      label: { en: "Backend Engineering", de: "Backend-Entwicklung" },
+      skills: [
+        "Java",
+        "Jakarta EE",
+        "Quarkus",
+        "Open Liberty",
+        "REST APIs",
+        "SQL",
+      ],
+    },
+    {
+      label: { en: "Platform & Operations", de: "Plattform & Betrieb" },
+      skills: ["OpenShift", "Splunk", "Dynatrace", "XL Release"],
+    },
+    {
+      label: { en: "Data", de: "Daten" },
+      skills: ["Microsoft SQL Server", "MongoDB"],
+    },
+    {
+      label: { en: "Frontend", de: "Frontend" },
+      skills: ["Angular", "TypeScript", "React"],
+    },
+    {
+      label: {
+        en: "AI-assisted Engineering",
+        de: "KI-gestützte Entwicklung",
+      },
+      skills: [
+        "Claude Code",
+        "GitHub Copilot",
+        {
+          en: "Agentic Development Workflows",
+          de: "Agentische Entwicklungs-Workflows",
+        },
+      ],
+    },
   ],
-  aiSkills: [
-    "Claude Code",
-    "GitHub Copilot",
-    "Google Antigravity",
-    "Google Stitch",
-    "Google Pomelli",
-  ],
+  // The personal site and blog live in the header links — this section is for
+  // products that were conceived, built and shipped end to end.
   projects: [
     {
-      title: "Homepage",
-      techStack: ["Side Project", "Astro", "Vite"],
-      description: {
-        en: "My personal Website",
-        de: "Meine persönliche Webseite",
-      },
-      logo: ConsultlyLogo,
-      link: {
-        label: "gnadlinger.me",
-        href: "https://gnadlinger.me/",
-      },
-    },
-    {
-      title: "Blog",
-      techStack: ["Side Project", "Storyblok", "Astro"],
-      description: {
-        en: "My personal Blog",
-        de: "Mein persönlicher Blog",
-      },
-      logo: ConsultlyLogo,
-      link: {
-        label: "blog.gnadlinger.me",
-        href: "https://blog.gnadlinger.me/",
-      },
-    },
-    {
       title: "Kaydo",
-      techStack: ["Side Project", "React", "Vite"],
+      techStack: ["React", "Vite"],
       description: {
-        en: "A private social media platform",
-        de: "Eine private Social-Media-Plattform",
+        en: "Conceived, built and shipped a private social platform end to end — from product concept to a running service.",
+        de: "Eine private Social-Media-Plattform, eigenständig konzipiert, entwickelt und veröffentlicht — von der Produktidee bis zum laufenden Dienst.",
       },
       logo: ConsultlyLogo,
       link: {
@@ -169,29 +258,29 @@ export const RESUME_DATA = {
       },
     },
     {
-      title: "Flexpoll",
-      techStack: ["Side Project", "React", "Vite"],
-      description: {
-        en: "A polling platform with multiple poll types including location and live polls",
-        de: "Eine Abstimmungsplattform mit verschiedenen Umfragetypen wie Standort- und Live-Abstimmungen",
-      },
-      logo: ConsultlyLogo,
-      link: {
-        label: "flexpoll.app",
-        href: "https://flexpoll.app",
-      },
-    },
-    {
       title: "myFAOS",
-      techStack: ["Side Project", "React", "Vite", "Firebase"],
+      techStack: ["React", "Vite", "Firebase"],
       description: {
-        en: "A mobile-first family organizer with a shared calendar, tasks and child documentation",
-        de: "Ein mobile-first Familienorganizer mit geteiltem Kalender, Aufgaben und Kinddokumentation",
+        en: "Designed and shipped a mobile-first family organizer with a shared calendar, tasks and child documentation.",
+        de: "Mobile-first Familienorganizer mit geteiltem Kalender, Aufgaben und Kinddokumentation — entworfen und veröffentlicht.",
       },
       logo: ConsultlyLogo,
       link: {
         label: "myfaos.app",
         href: "https://myfaos.app",
+      },
+    },
+    {
+      title: "Flexpoll",
+      techStack: ["React", "Vite"],
+      description: {
+        en: "Built and maintain a polling platform supporting several poll types, including location-based and live polls.",
+        de: "Abstimmungsplattform mit mehreren Umfragetypen, darunter standortbasierte und Live-Abstimmungen — entwickelt und betrieben.",
+      },
+      logo: ConsultlyLogo,
+      link: {
+        label: "flexpoll.app",
+        href: "https://flexpoll.app",
       },
     },
   ],

--- a/src/data/resume-data.tsx
+++ b/src/data/resume-data.tsx
@@ -49,6 +49,16 @@ export const RESUME_DATA = {
       de: "Zwischen hellem und dunklem Modus wechseln",
     },
   },
+  // Feeds schema.org/Person `knowsAbout`. Kept next to the rest of the content
+  // so the structured data cannot drift away from what the page claims.
+  knowsAbout: [
+    "SEPA",
+    "EBICS",
+    { en: "Payment Systems", de: "Zahlungsverkehrssysteme" },
+    { en: "Corporate Banking", de: "Firmenkundengeschäft" },
+    "Java",
+    { en: "Product Ownership", de: "Product Ownership" },
+  ],
   // Served from /public so the CV does not depend on GitHub being reachable
   // at render time. Replace the file to change the picture.
   avatarUrl: "/avatar.jpg",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -5,22 +5,21 @@
  * automatically; locally it falls back to the dev server so relative metadata
  * URLs still resolve.
  */
+// The domain the CV is published under. It also appears in the JSON-LD `url`
+// and in the sameAs identity graph shared with the other properties, so it is
+// stated here rather than left to an env var that a build can silently miss.
+export const CANONICAL_ORIGIN = "https://cv.gnadlinger.me";
+
 const configured =
   process.env.NEXT_PUBLIC_SITE_URL ??
   (process.env.VERCEL_PROJECT_PRODUCTION_URL
     ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
     : undefined);
 
-// A silent localhost fallback would ship canonical, sitemap and OpenGraph URLs
-// pointing at the developer's machine, which is hard to notice after the fact.
-if (
-  !configured &&
-  process.env.NODE_ENV === "production" &&
-  typeof window === "undefined"
-) {
-  console.warn(
-    "[cv] NEXT_PUBLIC_SITE_URL is not set — metadata, sitemap and robots.txt will point at http://localhost:3000.",
-  );
-}
-
-export const siteUrl = configured ?? "http://localhost:3000";
+// A localhost fallback in a production build would ship canonical, sitemap and
+// OpenGraph URLs pointing at the developer's machine. Only `next dev` gets it.
+export const siteUrl =
+  configured ??
+  (process.env.NODE_ENV === "production"
+    ? CANONICAL_ORIGIN
+    : "http://localhost:3000");

--- a/tests/cv.spec.ts
+++ b/tests/cv.spec.ts
@@ -12,7 +12,7 @@ test.describe("language routing", () => {
     await page.goto("/en");
     await expect(page.locator("html")).toHaveAttribute("lang", "en");
     await expect(
-      page.getByRole("heading", { name: "Work Experience" }),
+      page.getByRole("heading", { name: "Professional Experience" }),
     ).toBeVisible();
 
     await page.goto("/de");
@@ -40,6 +40,43 @@ test.describe("language routing", () => {
 
   test("an unknown language 404s", async ({ request }) => {
     expect((await request.get("/fr")).status()).toBe(404);
+  });
+});
+
+test.describe("positioning", () => {
+  // The tenure used to render as one combined "Full Stack Developer & Product
+  // Owner" block, which buried the move into payments. Both phases have to
+  // stay visible as separate roles with their own date ranges.
+  test("the career phases are shown as two distinct roles", async ({
+    page,
+  }) => {
+    await page.goto("/en");
+
+    await expect(
+      page.getByRole("heading", { name: "Payments & Backend Engineer" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "Full Stack Developer & Product Owner",
+      }),
+    ).toBeVisible();
+
+    await expect(page.getByText("2023 - Present")).toBeVisible();
+    await expect(page.getByText("2018 - 2022")).toBeVisible();
+  });
+
+  test("the headline states the positioning in both languages", async ({
+    page,
+  }) => {
+    await page.goto("/en");
+    await expect(
+      page.getByText("Building reliable financial infrastructure"),
+    ).toBeVisible();
+
+    await page.goto("/de");
+    await expect(
+      page.getByText("Verlässliche Finanzinfrastruktur"),
+    ).toBeVisible();
   });
 });
 
@@ -76,7 +113,9 @@ test.describe("print output", () => {
     await page.goto("/en");
     await page.emulateMedia({ media: "print" });
 
-    await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Selected Projects" }),
+    ).toBeVisible();
     // Regression guard: the section used to be print:hidden, so the projects
     // were missing from the PDF that actually gets sent to people.
     for (const project of ["myFAOS", "Kaydo", "Flexpoll"]) {

--- a/tests/cv.spec.ts
+++ b/tests/cv.spec.ts
@@ -80,6 +80,52 @@ test.describe("positioning", () => {
   });
 });
 
+test.describe("structured data", () => {
+  const SAME_AS = [
+    "https://www.gnadlinger.me",
+    "https://blog.gnadlinger.me",
+    "https://github.com/Gnadi",
+    "https://www.linkedin.com/in/johannes-gnadlinger-842293271",
+    "https://stackoverflow.com/users/6504152/johannes-gnadlinger",
+  ];
+
+  for (const lang of ["en", "de"]) {
+    test(`/${lang} ships valid schema.org/Person in the static HTML`, async ({
+      request,
+    }) => {
+      const html = await (await request.get(`/${lang}`)).text();
+      const match = html.match(
+        /<script type="application\/ld\+json">(.*?)<\/script>/s,
+      );
+      expect(match, "no JSON-LD block in the prerendered HTML").not.toBeNull();
+
+      const person = JSON.parse(match![1]);
+      expect(person["@type"]).toBe("Person");
+      expect(person.name).toBe("Johannes Gnadlinger");
+      expect(person.jobTitle).toBe("Payments & Backend Engineer");
+      expect(person.worksFor.name).toBe("Raiffeisen Software GmbH");
+      expect(person.address.addressLocality).toBe("Linz");
+      expect(person.address.addressCountry).toBe("AT");
+      expect(person.image).toMatch(/^https?:\/\/.+\/avatar\.jpg$/);
+      // The identity graph has to stay byte-identical across every property,
+      // so this asserts the exact set rather than "contains".
+      expect([...person.sameAs].sort()).toEqual([...SAME_AS].sort());
+    });
+  }
+
+  test("the page title carries the canonical positioning", async ({ page }) => {
+    await page.goto("/en");
+    await expect(page).toHaveTitle(
+      "Johannes Gnadlinger — Payments & Backend Engineer",
+    );
+
+    await page.goto("/de");
+    await expect(page).toHaveTitle(
+      "Johannes Gnadlinger — Payments & Backend Engineer",
+    );
+  });
+});
+
 test.describe("accessibility", () => {
   test("each social link has its own accessible name", async ({ page }) => {
     await page.goto("/en");
@@ -125,20 +171,27 @@ test.describe("print output", () => {
     await expect(page.getByText("myfaos.app", { exact: true })).toBeVisible();
   });
 
-  test("the printed CV fits on one A4 page", async ({ page }) => {
-    // A4 at 96dpi, so the print layout is measured at the width it prints at.
-    await page.setViewportSize({ width: 794, height: 1123 });
-    await page.goto("/en");
-    await page.emulateMedia({ media: "print" });
-    // A4 at 96dpi minus the 1.2cm page margins declared in globals.css.
-    // Measured on <body>: documentElement.scrollHeight never reports less
-    // than the viewport, which would mask a CV that already fits.
-    const printableHeight = 1123 - 2 * 45;
-    const height = await page.evaluate(() =>
-      Math.ceil(document.body.getBoundingClientRect().height),
-    );
-    expect(height).toBeLessThanOrEqual(printableHeight);
-  });
+  // Both languages, because German runs materially longer than English: the
+  // German CV silently spilled onto a second page while this test, which only
+  // ever loaded /en, stayed green.
+  for (const lang of ["en", "de"]) {
+    test(`the printed ${lang.toUpperCase()} CV fits on one A4 page`, async ({
+      page,
+    }) => {
+      // A4 at 96dpi, so the print layout is measured at the width it prints at.
+      await page.setViewportSize({ width: 794, height: 1123 });
+      await page.goto(`/${lang}`);
+      await page.emulateMedia({ media: "print" });
+      // A4 at 96dpi minus the 1.2cm page margins declared in globals.css.
+      // Measured on <body>: documentElement.scrollHeight never reports less
+      // than the viewport, which would mask a CV that already fits.
+      const printableHeight = 1123 - 2 * 45;
+      const height = await page.evaluate(() =>
+        Math.ceil(document.body.getBoundingClientRect().height),
+      );
+      expect(height).toBeLessThanOrEqual(printableHeight);
+    });
+  }
 
   test("print stays light even in dark mode", async ({ page }) => {
     await page.goto("/en");


### PR DESCRIPTION
The CV read as a broad "Full Stack Developer / Product Owner" and buried
the move into payments inside one combined 2018-now block. Restructure it
so the senior payments/backend positioning lands in the first few seconds.

- Give the headline its own weight: role, tagline and credentials replace
  the single muted intro paragraph.
- Split the Raiffeisen tenure into the two phases the existing description
  already encoded: Payments & Backend Engineer (2023-Present) and Full
  Stack Developer & Product Owner (2018-2022), each with a semantic
  bullet list instead of a pre-wrapped string.
- Group the flat skill cloud into Payments, Backend, Platform, Data,
  Frontend and AI-assisted Engineering, and drop the low-value AI tools.
- Reorder to Summary, Experience, Core Expertise, Projects, Education, so
  professional experience outweighs side projects.
- Reduce Selected Projects to products that were shipped end to end;
  the homepage and blog move to the header links.
- Drop the secondary-school entry and state the WKO qualification as
  NQF/EQF Level 6 rather than implying an academic degree.

Two work cards with bullets no longer fit A4, so print gets tighter
metrics for the bullet lists and section gaps.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G1Tzx8BN91v3egXH2qZQqC